### PR TITLE
Implement first login flow; add isFirstLogin to User, update onboardi…

### DIFF
--- a/api/user.ts
+++ b/api/user.ts
@@ -13,9 +13,16 @@ export const getUserInfo = async (): Promise<UserInfo> => {
     return data;
 };
 
-export const updateUserInfo = async (
-    params: UpdateUserInfoParams
-): Promise<UserInfo> => {
+export const getUserPhoto = async (userId: string): Promise<string | null> => {
+    try {
+        const { data } = await privateApi.get<string>(`/user/${userId}/photo`);
+        return data;
+    } catch {
+        return null;
+    }
+};
+
+export const updateUserInfo = async (params: UpdateUserInfoParams): Promise<UserInfo> => {
     const formData = new FormData();
     formData.append('firstName', params.firstName);
     formData.append('lastName', params.lastName);
@@ -25,6 +32,7 @@ export const updateUserInfo = async (
     const filename = uri.split('/').pop()!;
     const match = /\.(\w+)$/.exec(filename);
     const mimeType = match ? `image/${match[1]}` : 'image/jpeg';
+
     formData.append('photo', {
         uri,
         name: filename,
@@ -34,7 +42,13 @@ export const updateUserInfo = async (
     const { data } = await privateApi.post<UserInfo>(
         '/user/info',
         formData,
-        { headers: { 'Content-Type': 'multipart/form-data' } }
+        {
+            headers: {
+                'Content-Type': 'multipart/form-data',
+                'Accept': 'application/json'
+            },
+            timeout: 30000
+        }
     );
 
     return data;

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -4,17 +4,14 @@ import { useAuth } from '@/context/AuthContext';
 import LoginScreen from '@/components/auth/LoginScreen';
 import UserProfile from '@/components/user/UserProfileScreen';
 import UserSetupScreen from "@/components/user/UserSetupScreen";
-import {useUser} from "@/context/UserContext";
 
 export default function HomeScreen() {
     const { user} = useAuth();
-    const { userInfo} = useUser();
-
 
     if (!user) {
         return <LoginScreen />;
     }
-    if (!userInfo) {
+    if (user.isFirstLogin) {
         return <UserSetupScreen />;
     }
     return <UserProfile />;

--- a/components/user/UserProfileScreen.tsx
+++ b/components/user/UserProfileScreen.tsx
@@ -13,7 +13,7 @@ import { AuthContext } from '@/context/AuthContext';
 import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
 import { useUser } from '@/context/UserContext';
-
+import { getUserPhoto } from '@/api/user';
 
 export default function UserProfileScreen() {
     const { user, logout } = useContext(AuthContext);
@@ -21,22 +21,17 @@ export default function UserProfileScreen() {
     const [photoUri, setPhotoUri] = useState<string | null>(null);
     const [photoLoading, setPhotoLoading] = useState(true);
 
-    const apiBaseUrl = 'http://192.168.0.30:8080/api';
 
     useEffect(() => {
-        if (userInfo?.id) {
-            const uri = `${apiBaseUrl}/user/${userInfo.id}/photo`;
-            // Optionally test fetch staxtus
-            fetch(uri)
-                .then(res => {
-                    if (res.ok) {
-                        setPhotoUri(uri);
-                    } else {
-                        setPhotoUri(null);
-                    }
-                })
-                .finally(() => setPhotoLoading(false));
-        }
+        const fetchPhoto = async () => {
+            if (userInfo?.id) {
+                setPhotoLoading(true);
+                const uri = await getUserPhoto(userInfo.id);
+                setPhotoUri(uri);
+                setPhotoLoading(false);
+            }
+        };
+        fetchPhoto();
     }, [userInfo]);
 
     if (userLoading || photoLoading) return <ActivityIndicator />;
@@ -86,13 +81,7 @@ export default function UserProfileScreen() {
                                 style={styles.avatar}
                                 contentFit="cover"
                             />
-                        ) : (
-                            <Image
-                                source={require('@/assets/images/Jodo.png')}
-                                style={styles.avatar}
-                                contentFit="cover"
-                            />
-                        )}
+                        ) : (<></>)}
                     </View>
 
 

--- a/components/user/UserSetupScreen.tsx
+++ b/components/user/UserSetupScreen.tsx
@@ -41,7 +41,7 @@ export default function UserSetupScreen() {
         }
 
         const result = await ImagePicker.launchImageLibraryAsync({
-            mediaTypes: ['images'],            // zamiast MediaTypeOptions :contentReference[oaicite:1]{index=1}
+            mediaTypes: ['images'],
             allowsEditing: true,
             aspect: [1, 1],
             quality: 1,

--- a/context/UserContext.tsx
+++ b/context/UserContext.tsx
@@ -34,7 +34,7 @@ interface UserProviderProps {
 export const UserProvider = ({ children }: UserProviderProps) => {
     const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
     const [loading, setLoading] = useState(true);
-    const { user } = useAuth();
+    const { user, completeFirstLogin } = useAuth();
 
     const refreshUserInfo = async () => {
         setLoading(true);
@@ -51,13 +51,14 @@ export const UserProvider = ({ children }: UserProviderProps) => {
         try {
             const updated = await apiUpdateUserInfo(params);
             setUserInfo(updated);
+            await completeFirstLogin();
         } finally {
             setLoading(false);
         }
     };
 
     useEffect(() => {
-        if (user) {
+        if (!user?.isFirstLogin) {
             refreshUserInfo();
         } else {
             setUserInfo(null);

--- a/types/User.ts
+++ b/types/User.ts
@@ -2,4 +2,5 @@
 export interface User {
     id: string;
     email: string;
+    isFirstLogin: boolean;
 }


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across the API client, user management, and authentication contexts. Key updates include improving API request handling, adding support for user photos, and introducing a mechanism to track and handle a user's first login. Below is a categorized summary of the most important changes:

### API Enhancements
* Updated `privateApi` request interceptor to handle `FormData` by removing the `Content-Type` header when necessary.
* Added error propagation in the `privateApi` response interceptor by rejecting the refresh token error explicitly.

### User Management
* Added `getUserPhoto` function to fetch user profile photos and integrated it into `UserProfileScreen`. This replaces hardcoded logic and improves maintainability. [[1]](diffhunk://#diff-237f9fab14d370381e072d6f02f24cb878b7e73d1ab7ad877b3817cb6a35a179L16-R25) [[2]](diffhunk://#diff-9c9300b62dc3a50cac5577e67496d8838fbda4db87568d50cdd3d0287651c531L16-R34)
* Enhanced `updateUserInfo` API call to include a timeout and ensure the `Accept` header is set to `application/json`.

### Authentication Updates
* Introduced `isFirstLogin` property in the `User` type to track a user's first login.
* Added `completeFirstLogin` method to `AuthContext` to update the `isFirstLogin` flag and persist changes securely. [[1]](diffhunk://#diff-31e0d99088ce815f0879cbaf2e04df20c359c18a068c9579cfd1920d7d1b666aR14-R23) [[2]](diffhunk://#diff-31e0d99088ce815f0879cbaf2e04df20c359c18a068c9579cfd1920d7d1b666aR34-L39) [[3]](diffhunk://#diff-31e0d99088ce815f0879cbaf2e04df20c359c18a068c9579cfd1920d7d1b666aL86-R95)

### UI Changes
* Updated `HomeScreen` logic to show `UserSetupScreen` for users on their first login instead of relying on `userInfo`.
* Simplified fallback logic for missing user photos in `UserProfileScreen`.…ng logic, and enhance user photo handling in profile and API